### PR TITLE
Initial draft on drone states and events

### DIFF
--- a/src/main/java/sysc3303/a1/group3/FireIncidentSubsystem.java
+++ b/src/main/java/sysc3303/a1/group3/FireIncidentSubsystem.java
@@ -11,7 +11,7 @@ import java.util.List;
  * This subsystem reads fire incident events from an input file, sends them to the Scheduler, and waits for
  * acknowledgments.
  */
-class FireIncidentSubsystem implements Runnable {
+public class FireIncidentSubsystem implements Runnable {
 
     private final Scheduler scheduler;
     private List<Event> events;

--- a/src/main/java/sysc3303/a1/group3/Main.java
+++ b/src/main/java/sysc3303/a1/group3/Main.java
@@ -1,5 +1,7 @@
 package sysc3303.a1.group3;
 
+import sysc3303.a1.group3.drone.Drone;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Scanner;

--- a/src/main/java/sysc3303/a1/group3/Scheduler.java
+++ b/src/main/java/sysc3303/a1/group3/Scheduler.java
@@ -1,5 +1,7 @@
 package sysc3303.a1.group3;
 
+import sysc3303.a1.group3.drone.Drone;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/sysc3303/a1/group3/drone/BaseDroneState.java
+++ b/src/main/java/sysc3303/a1/group3/drone/BaseDroneState.java
@@ -1,0 +1,44 @@
+package sysc3303.a1.group3.drone;
+
+/**
+ * A base implementation of {@link DroneState} that makes State implementations easier.
+ * Note that this does not include {@link #triggerEntryWork(Drone)} and {@link #triggerExitWork(Drone)}.
+ */
+public interface BaseDroneState extends DroneState {
+
+    @Override
+    default void onZoneInstruction(Drone drone) {
+        throwIllegalState(drone);
+    }
+
+    @Override
+    default void onZoneArrival(Drone drone) {
+        throwIllegalState(drone);
+    }
+
+    @Override
+    default void onDropInstruction(Drone drone) {
+        throwIllegalState(drone);
+    }
+
+    @Override
+    default void onDropComplete(Drone drone) {
+        throwIllegalState(drone);
+    }
+
+    @Override
+    default void onBaseArrival(Drone drone) {
+        throwIllegalState(drone);
+    }
+
+    @Override
+    default void onShutdown(Drone drone) {
+        // Remember that #triggerExitWork will be invoked
+        drone.transitionState(DroneReturning.class);
+    }
+
+    @Override
+    default void onFault(Drone drone) {
+        throw new UnsupportedOperationException("To be implemented in iteration 4");
+    }
+}

--- a/src/main/java/sysc3303/a1/group3/drone/Drone.java
+++ b/src/main/java/sysc3303/a1/group3/drone/Drone.java
@@ -1,4 +1,7 @@
-package sysc3303.a1.group3;
+package sysc3303.a1.group3.drone;
+
+import sysc3303.a1.group3.Event;
+import sysc3303.a1.group3.Scheduler;
 
 public class Drone implements Runnable {
 
@@ -27,5 +30,14 @@ public class Drone implements Runnable {
     // package private for testing purposes
     public void requestEvent() {
         currentEvent = scheduler.removeEvent();
+    }
+
+    /**
+     * @return the current event that this drone is handling, or null if there is none
+     * @deprecated likely to change or be removed in the future. should only be used for testing.
+     */
+    @Deprecated(forRemoval = true)
+    public Event getCurrentEvent() {
+        return currentEvent;
     }
 }

--- a/src/main/java/sysc3303/a1/group3/drone/Drone.java
+++ b/src/main/java/sysc3303/a1/group3/drone/Drone.java
@@ -5,12 +5,30 @@ import sysc3303.a1.group3.Scheduler;
 
 public class Drone implements Runnable {
 
+    private static final DroneStates STATES = new DroneStates();
+
     private final Scheduler scheduler;
     // package private for testing purposes
     Event currentEvent;
 
+    private DroneState state;
+
     public Drone(Scheduler scheduler) {
         this.scheduler = scheduler;
+        this.state = STATES.retrieve(DroneIdle.class);
+    }
+
+    /**
+     * Transitions from the current state to a new state.
+     * {@link DroneState#triggerExitWork(Drone)} is invoked on the current state before the transition,
+     * after which {@link DroneState#triggerEntryWork(Drone)} is invoked on the new state.
+     *
+     * @param state the new state to transition to
+     */
+    void transitionState(Class<? extends DroneState> state) {
+        this.state.triggerExitWork(this);
+        this.state = STATES.retrieve(state);
+        this.state.triggerEntryWork(this);
     }
 
     //Start the Drone, wait for notifications.
@@ -39,5 +57,12 @@ public class Drone implements Runnable {
     @Deprecated(forRemoval = true)
     public Event getCurrentEvent() {
         return currentEvent;
+    }
+
+    /**
+     * @return the Scheduler that owns this Drone
+     */
+    Scheduler getScheduler() {
+        return scheduler;
     }
 }

--- a/src/main/java/sysc3303/a1/group3/drone/DroneDroppingFoam.java
+++ b/src/main/java/sysc3303/a1/group3/drone/DroneDroppingFoam.java
@@ -1,0 +1,14 @@
+package sysc3303.a1.group3.drone;
+
+public class DroneDroppingFoam implements BaseDroneState {
+
+    @Override
+    public void triggerEntryWork(Drone drone) {
+        // todo open nozzles/doors?
+    }
+
+    @Override
+    public void triggerExitWork(Drone drone) {
+        // todo close nozzles/doors?
+    }
+}

--- a/src/main/java/sysc3303/a1/group3/drone/DroneEnRoute.java
+++ b/src/main/java/sysc3303/a1/group3/drone/DroneEnRoute.java
@@ -1,0 +1,19 @@
+package sysc3303.a1.group3.drone;
+
+public class DroneEnRoute implements BaseDroneState {
+
+    @Override
+    public void triggerEntryWork(Drone drone) {
+        // todo simulate moving to fly height if the drone isn't already? start travel simulation?
+    }
+
+    @Override
+    public void triggerExitWork(Drone drone) {
+        // todo ?
+    }
+
+    @Override
+    public void onZoneArrival(Drone drone) {
+        drone.transitionState(DroneInZone.class);
+    }
+}

--- a/src/main/java/sysc3303/a1/group3/drone/DroneFaulted.java
+++ b/src/main/java/sysc3303/a1/group3/drone/DroneFaulted.java
@@ -1,0 +1,15 @@
+package sysc3303.a1.group3.drone;
+
+public class DroneFaulted implements BaseDroneState {
+
+
+    @Override
+    public void triggerEntryWork(Drone drone) {
+        throw new UnsupportedOperationException("To be implemented in iteration 4");
+    }
+
+    @Override
+    public void triggerExitWork(Drone drone) {
+        throw new UnsupportedOperationException("To be implemented in iteration 4");
+    }
+}

--- a/src/main/java/sysc3303/a1/group3/drone/DroneIdle.java
+++ b/src/main/java/sysc3303/a1/group3/drone/DroneIdle.java
@@ -1,0 +1,19 @@
+package sysc3303.a1.group3.drone;
+
+public class DroneIdle implements BaseDroneState {
+
+    @Override
+    public void triggerEntryWork(Drone drone) {
+        // todo tell scheduler that drone arrived at the base? does the scheduler or the drone initiate foam reloading?
+    }
+
+    @Override
+    public void triggerExitWork(Drone drone) {
+        // todo ?
+    }
+
+    @Override
+    public void onZoneInstruction(Drone drone) {
+        drone.transitionState(DroneEnRoute.class);
+    }
+}

--- a/src/main/java/sysc3303/a1/group3/drone/DroneInZone.java
+++ b/src/main/java/sysc3303/a1/group3/drone/DroneInZone.java
@@ -1,0 +1,19 @@
+package sysc3303.a1.group3.drone;
+
+public class DroneInZone implements BaseDroneState {
+
+    @Override
+    public void triggerEntryWork(Drone drone) {
+        // todo inform scheduler that drone has arrived
+    }
+
+    @Override
+    public void triggerExitWork(Drone drone) {
+        // todo ?
+    }
+
+    @Override
+    public void onDropInstruction(Drone drone) {
+        drone.transitionState(DroneDroppingFoam.class);
+    }
+}

--- a/src/main/java/sysc3303/a1/group3/drone/DroneReturning.java
+++ b/src/main/java/sysc3303/a1/group3/drone/DroneReturning.java
@@ -1,0 +1,16 @@
+package sysc3303.a1.group3.drone;
+
+public class DroneReturning implements BaseDroneState {
+
+    // similar to DroneEnRoute?
+
+    @Override
+    public void triggerEntryWork(Drone drone) {
+        // todo
+    }
+
+    @Override
+    public void triggerExitWork(Drone drone) {
+        // todo
+    }
+}

--- a/src/main/java/sysc3303/a1/group3/drone/DroneState.java
+++ b/src/main/java/sysc3303/a1/group3/drone/DroneState.java
@@ -1,4 +1,82 @@
 package sysc3303.a1.group3.drone;
 
+/**
+ * A type of drone state, allowing for customizable event handling related to drones.
+ */
 public interface DroneState {
+
+    /**
+     * Trigger for when this state becomes the current state.
+     *
+     * @param drone the Drone entering this state
+     */
+    void triggerEntryWork(Drone drone);
+
+    /**
+     * Trigger for when this state is no longer the current state.
+     *
+     * @param drone the Drone exiting this state
+     */
+    void triggerExitWork(Drone drone);
+
+    /**
+     * Event handler for the Scheduler instructing a drone that it should go to a zone.
+     *
+     * @param drone the drone being instructed
+     */
+    void onZoneInstruction(Drone drone);
+    // todo more parameters needed?
+
+    /**
+     * Event handler for when a drone arrives at the destination zone.
+     *
+     * @param drone the drone that arrived
+     */
+    void onZoneArrival(Drone drone);
+
+    /**
+     * Event handler for the Scheduler instructing a drone to begin dropping foam.
+     *
+     * @param drone the drone being instructed
+     */
+    void onDropInstruction(Drone drone);
+
+    /**
+     * Event handler for a drone completing a foam drop.
+     *
+     * @param drone the drone that completed a foam drop
+     */
+    void onDropComplete(Drone drone);
+
+    /**
+     * Event handler for a drone arriving at the base
+     *
+     * @param drone the drone that arrived at the base
+     */
+    void onBaseArrival(Drone drone);
+
+    /**
+     * Event handler for the system beginning shutdown
+     *
+     * @param drone the drone being instructed to comply with the shutdown
+     */
+    void onShutdown(Drone drone);
+
+    /**
+     * Event handler for a drone experiencing a fault
+     *
+     * @param drone experiencing a fault
+     */
+    void onFault(Drone drone);
+
+    /**
+     * Throws an {@link IllegalArgumentException} with a message indicating
+     * that an event handler method was invoked in an unexpected state.
+     *
+     * @param drone the drone that the event handler was invoked for
+     * @throws IllegalStateException always thrown
+     */
+    default void throwIllegalState(Drone drone) throws IllegalStateException {
+        throw new IllegalStateException(drone + " is in inappropriate state " + this.getClass().getSimpleName());
+    }
 }

--- a/src/main/java/sysc3303/a1/group3/drone/DroneState.java
+++ b/src/main/java/sysc3303/a1/group3/drone/DroneState.java
@@ -1,0 +1,4 @@
+package sysc3303.a1.group3.drone;
+
+public interface DroneState {
+}

--- a/src/main/java/sysc3303/a1/group3/drone/DroneStates.java
+++ b/src/main/java/sysc3303/a1/group3/drone/DroneStates.java
@@ -1,0 +1,61 @@
+package sysc3303.a1.group3.drone;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Registry of {@link DroneState} instances with the goal of ensuring only one instance of each type is used.
+ */
+public final class DroneStates {
+
+    private final Map<Class<? extends DroneState>, DroneState> states = new HashMap<>();
+
+    /**
+     * Creates a DroneStates with no registered states.
+     */
+    public DroneStates() {
+
+    }
+
+    /**
+     * Registers a state instance.
+     *
+     * @param state the state instance to register
+     * @throws IllegalArgumentException if there is already an instance of the same class registered
+     */
+    public void register(DroneState state) {
+        if (states.containsKey(state.getClass())) {
+            throw new IllegalArgumentException("Can't register state " + state + " because an instance of " + state.getClass() + " is already registered");
+        }
+        states.put(state.getClass(), state);
+    }
+
+    /**
+     * Retrieves the instance of the desired state.
+     *
+     * @param stateClass the state class desired
+     * @return the instance of the state
+     * @param <T> the specific state type desired
+     * @throws IllegalArgumentException if there is not an instance of the desired state registered
+     */
+    public <T extends DroneState> T retrieve(Class<T> stateClass) {
+        if (!states.containsKey(stateClass)) {
+            throw new IllegalArgumentException(stateClass + " is not registered");
+        }
+        return stateClass.cast(states.get(stateClass));
+    }
+
+    /**
+     * @return a new DroneStates instance with the default states registered
+     */
+    public static DroneStates withDefaults() {
+        DroneStates states = new DroneStates();
+        states.register(new DroneIdle());
+        states.register(new DroneEnRoute());
+        states.register(new DroneInZone());
+        states.register(new DroneDroppingFoam());
+        states.register(new DroneReturning());
+        states.register(new DroneFaulted());
+        return states;
+    }
+}

--- a/src/test/java/sysc3303/a1/group3/FireIncidentSubsystemTest.java
+++ b/src/test/java/sysc3303/a1/group3/FireIncidentSubsystemTest.java
@@ -2,6 +2,7 @@ package sysc3303.a1.group3;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import sysc3303.a1.group3.drone.Drone;
 
 /*
 NOTE: As mentioned in other test files, if you find that synchronized method tests are missing, then they're

--- a/src/test/java/sysc3303/a1/group3/SchedulerTest.java
+++ b/src/test/java/sysc3303/a1/group3/SchedulerTest.java
@@ -2,6 +2,7 @@ package sysc3303.a1.group3;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import sysc3303.a1.group3.drone.Drone;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -60,8 +61,9 @@ class SchedulerTest {
         Thread.sleep(500);
 
         // Verify that the drone received the event, and that it equals the one prior
-        assertNotNull(drone.currentEvent);
-        assertEquals(event, drone.currentEvent);
+        Event receivedEvent = drone.getCurrentEvent();
+        assertNotNull(receivedEvent);
+        assertEquals(event, receivedEvent);
     }
 
     //Similar to before, but testing if the drone shuts off afterward.
@@ -77,7 +79,7 @@ class SchedulerTest {
 
         // Verify that the shutoff flag is set and that the drone is off and has no event.
         assertTrue(scheduler.getShutOff());
-        assertNull(drone.currentEvent);
+        assertNull(drone.getCurrentEvent());
     }
 
 }

--- a/src/test/java/sysc3303/a1/group3/WholeSystemTest.java
+++ b/src/test/java/sysc3303/a1/group3/WholeSystemTest.java
@@ -2,6 +2,7 @@ package sysc3303.a1.group3;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import sysc3303.a1.group3.drone.Drone;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/test/java/sysc3303/a1/group3/drone/DroneStatesTest.java
+++ b/src/test/java/sysc3303/a1/group3/drone/DroneStatesTest.java
@@ -1,0 +1,46 @@
+package sysc3303.a1.group3.drone;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DroneStatesTest {
+
+    DroneStates droneStates;
+    DroneState droneIdle;
+
+    @BeforeEach
+    void beforeEach() {
+        droneStates = new DroneStates();
+        droneIdle = new DroneIdle();
+    }
+
+    @Test
+    void testRetrieve() {
+        droneStates.register(droneIdle);
+        // Ensure an instance can be registered and retrieved
+        assertSame(droneIdle, droneStates.retrieve(DroneIdle.class));
+    }
+
+    @Test
+    void testNotRegistered() {
+        // Ensure an instance is not retrieved if it hasn't been registered
+        assertThrows(IllegalArgumentException.class, () -> droneStates.retrieve(DroneIdle.class));
+    }
+
+    @Test
+    void testAlreadyRegistered() {
+        droneStates.register(droneIdle);
+        // Ensure no instance of the same type can be registered
+        assertThrows(IllegalArgumentException.class, () -> droneStates.register(droneIdle));
+        assertThrows(IllegalArgumentException.class, () -> droneStates.register(new DroneIdle()));
+    }
+
+    @Test
+    void testWithDefaults() {
+        // Ensure that static factory provides defaults
+        droneStates = DroneStates.withDefaults();
+        assertInstanceOf(DroneIdle.class, droneStates.retrieve(DroneIdle.class));
+    }
+}

--- a/src/test/java/sysc3303/a1/group3/drone/DroneTest.java
+++ b/src/test/java/sysc3303/a1/group3/drone/DroneTest.java
@@ -1,7 +1,12 @@
-package sysc3303.a1.group3;
+package sysc3303.a1.group3.drone;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import sysc3303.a1.group3.Event;
+import sysc3303.a1.group3.FireIncidentSubsystem;
+import sysc3303.a1.group3.Main;
+import sysc3303.a1.group3.Scheduler;
+import sysc3303.a1.group3.Severity;
 
 import java.io.IOException;
 import java.io.InputStream;


### PR DESCRIPTION
- Moved drone stuff into its own package
- DroneStates is basically the wrapper for the states hashmap. Class objects are used for identifying the instances, rather than strings like in the lecture example.
- DroneState is the main class of interest
- More general state and methods still need to be added to the drone (e.g. liquid level, nozzle status, etc?), which the states will then invoke as necessary? As a result, states are generally still not implemented apart from some transitions.
- How should the event handler methods be usually invoked? Will the packet handler invoke them directly, or invoke a method in the drone that delegates to the DroneState?