### PR TITLE
Starting UI Functions in Scheduler

### DIFF
--- a/src/main/java/sysc3303/a1/group3/drone/Drone.java
+++ b/src/main/java/sysc3303/a1/group3/drone/Drone.java
@@ -346,8 +346,8 @@ public class Drone implements Runnable {
         registerDroneToScheduler();
         listenForShutoff();
 
-        // send state and position every 2 seconds
-        stateUpdateScheduler.scheduleAtFixedRate(() -> sendStateToScheduler(state.getStateName()), 0, 2, TimeUnit.SECONDS);
+        // send state and position every second
+        stateUpdateScheduler.scheduleAtFixedRate(() -> sendStateToScheduler(state.getStateName()), 0, 1, TimeUnit.SECONDS);
 
         while (!shutdownFromFault && (!shutoff || !(state instanceof DroneIdle))) {
             if (PRINT_DRONE_ITERATIONS) {

--- a/src/main/java/sysc3303/a1/group3/physics/Kinematics.java
+++ b/src/main/java/sysc3303/a1/group3/physics/Kinematics.java
@@ -7,7 +7,7 @@ public class Kinematics {
     private static final double SECONDS_PER_TICK = Drone.DRONE_LOOP_SLEEP_MS / 1000.0;
 
     static final double EPSILON = Math.ulp(1.0d);
-    private final double ALLOWABLE_ERROR = 50; // zones are general 100x100 so 50 is a good error from center
+    private final double ALLOWABLE_ERROR = 10; 
 
     private final double maxSpeed;
     private final double maxSpeedSquared;


### PR DESCRIPTION
Please see function, "startUI()" in scheduler for where to add UI components. The comments should be descriptive enough to understand what is going on here. If you don't get it, lmk in discord and I can explain further.

Function, "stopUI" in scheduler is where you can put the UI clean up (e.g. if you need to close anything). The program should function the exact same right now, besides a lot of extra prints for you to see how to access the info you need. The program should also close correctly as before.

Right now, the additions give you these 2 functions and print out the information you will need for the UI. Drone locations, states, target/current events, current active fires, and the polling timer for them. If you need some other info for the UI lmk.

For now, I'll start bug fixing the nozzle repair state.